### PR TITLE
Updated JS filepath for new packist package

### DIFF
--- a/code/CookiePolicy.php
+++ b/code/CookiePolicy.php
@@ -23,7 +23,7 @@ class CookiePolicy extends Extension
             ));
 
             Requirements::javascript(THIRDPARTY_DIR.'/jquery/jquery.js');
-            Requirements::javascript('cookie-policy-notification/javascript/jquery.cookie.policy.min.js');
+            Requirements::javascript('cookiepolicy/javascript/jquery.cookie.policy.min.js');
             Requirements::customScript($cookiepolicyjssnippet->renderWith('CookiePolicyJSSnippet'));
         }
     }


### PR DESCRIPTION
Seeing that the other (old) packagist packages are abandoned and the active one is installed into ```cookiepolicy```, branch 3 needs to be updated to reflect the new filepath.